### PR TITLE
Put Cookie object on global

### DIFF
--- a/cookie.js
+++ b/cookie.js
@@ -1,4 +1,4 @@
-Cookie = {};
+this.Cookie = {};
 
 (function(exports) {
 
@@ -187,4 +187,4 @@ Cookie = {};
         return s;
     }
 
-})(Cookie);
+})(this.Cookie);


### PR DESCRIPTION
New meteor wraps script in a closure. This puts cookie back on the global window object.
